### PR TITLE
fix: image syntax parsing

### DIFF
--- a/widget-src/parser/BlockParser.tsx
+++ b/widget-src/parser/BlockParser.tsx
@@ -22,19 +22,19 @@ export class BlockParser {
       }
       // 圖片
       const imageMatch = line.match(
-        /^!\[(.*?)\]\((.*?)(?:\s*=\s*(\d+%?x?))?\)$/
+        /^!\[(.*?)\]\((.*?)(?:\s+"(.*?)")?\s*(?:=\s*(\d+(?:x\d+|%))?)?\)$/
       );
       if (imageMatch) {
         if (currentBlock) blocks.push(currentBlock);
-        let width = imageMatch[3] || "fill-parent";
-        width = width.replace("x", ""); // 刪除寬度中的 'x'
+        let width = imageMatch[4] || "fill-parent";
+        width = width.includes("x") ? width.split("x")[0] : width;
         let widthNumber: number | string = width.includes("%")
           ? parseFloat(width)
           : parseInt(width, 10);
         currentBlock = {
           type: "image",
           src: imageMatch[2], // 圖片 URL
-          alt: imageMatch[1], // 圖片替代文字
+          alt: imageMatch[1] || imageMatch[3] || "", // 圖片替代文字
           width: widthNumber || "fill-parent", // 圖片寬度
         };
         blocks.push(currentBlock);


### PR DESCRIPTION
handle syntax like

```md
![](https://octodex.github.com/images/minion.png =200x200)

![](https://octodex.github.com/images/minion.png "asdfasdfasdf")

![asdfasdfa wefawe](https://octodex.github.com/images/stormtroopocat.jpg "asdfasdf awef aew")
```